### PR TITLE
add tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +218,7 @@ dependencies = [
  "bootloader",
  "eyre",
  "kernel",
+ "test_kernel",
 ]
 
 [[package]]
@@ -225,6 +235,12 @@ name = "crc-catalog"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
+
+[[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam-utils"
@@ -445,6 +461,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,12 +680,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -694,6 +750,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
@@ -789,6 +851,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "syn"
 version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +887,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_kernel"
+version = "0.1.0"
+dependencies = [
+ "heapless",
+ "kernel",
+ "uart_16550",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -836,6 +913,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "uart_16550"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dc00444796f6c71f47c85397a35e9c4dbf9901902ac02386940d178e2b78687"
+dependencies = [
+ "bitflags 1.3.2",
+ "rustversion",
+ "x86",
 ]
 
 [[package]]
@@ -966,6 +1054,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x86"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2781db97787217ad2a2845c396a5efe286f87467a5810836db6d74926e94a385"
+dependencies = [
+ "bit_field",
+ "bitflags 1.3.2",
+ "raw-cpuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,12 @@ edition = "2021"
 bootloader = "0.11.4"
 kernel = { path = "kernel", artifact = "bin", target = "x86_64-unknown-none" }
 
+[dev-dependencies]
+bootloader = "0.11.4"
+test_kernel = { path = "tests/integration/test_kernel", artifact = "bin", target = "x86_64-unknown-none" }
+
 [dependencies]
 eyre = "0.6.8"
 
 [workspace]
-members = ["kernel"]
+members = ["kernel", "tests/integration/test_kernel"]

--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,6 @@ fn main() {
         .create_disk_image(&bios_path)
         .unwrap();
 
-    // pass the disk image paths as env variables to the `main.rs`
+    // pass the disk image paths as env variables to the `basic.rs`
     println!("cargo:rustc-env=BIOS_PATH={}", bios_path.display());
 }

--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,6 @@ fn main() {
         .create_disk_image(&bios_path)
         .unwrap();
 
-    // pass the disk image paths as env variables to the `basic.rs`
+    // pass the disk image paths as env variables to the `main.rs`
     println!("cargo:rustc-env=BIOS_PATH={}", bios_path.display());
 }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -12,3 +12,4 @@ bootloader_api = "0.11.4"
 noto-sans-mono-bitmap = "0.2.0"
 spin = "0.9.8"
 x86_64 = "0.14.10"
+

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -2,6 +2,20 @@
 #![no_main]
 #![feature(abi_x86_interrupt)]
 
+use bootloader_api::BootInfo;
+
 pub mod interrupt;
 pub mod logger;
 pub mod vga;
+
+pub use bootloader_api;
+pub use x86_64;
+
+pub fn init(boot_info: &'static mut BootInfo) {
+    interrupt::init();
+
+    let framebuffer = boot_info.framebuffer.as_mut().unwrap();
+    let vga = vga::Writer::new(framebuffer);
+
+    logger::init_global(vga);
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,0 +1,5 @@
+mod runner;
+
+test!(basic);
+test!(handle_stack_overflow);
+// test!(handle_breakpoint); // doesn't work 🥶

--- a/tests/integration/runner.rs
+++ b/tests/integration/runner.rs
@@ -1,0 +1,67 @@
+use bootloader::{BootConfig, DiskImageBuilder};
+use std::{
+    io,
+    path::Path,
+    process::{Command, Stdio},
+    thread,
+};
+
+/// Creates a test case that runs a binary form `test_kernel` crate in qemu.
+#[macro_export]
+macro_rules! test {
+    ($bin_name:ident) => {
+        #[test]
+        fn $bin_name() {
+            $crate::runner::run(env!(concat!(
+                "CARGO_BIN_FILE_TEST_KERNEL_",
+                stringify!($bin_name)
+            )));
+        }
+    };
+}
+
+pub fn run(path: &str) {
+    let path = Path::new(path);
+    let mut image_builder = DiskImageBuilder::new(path.to_path_buf());
+    let image_path = path.with_extension(".mbr");
+    image_builder
+        .set_boot_config(&{
+            let mut boot_config = BootConfig::default();
+            boot_config.serial_logging = false;
+            boot_config
+        })
+        .create_bios_image(&image_path)
+        .unwrap();
+
+    let mut child = Command::new("qemu-system-x86_64")
+        .arg("-drive")
+        .arg(format!("format=raw,file={}", image_path.display()))
+        .arg("-device")
+        .arg("isa-debug-exit,iobase=0xf4,iosize=0x04")
+        .arg("-serial")
+        .arg("stdio")
+        .arg("-display")
+        .arg("none")
+        .arg("--no-reboot")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let mut child_stdout = child.stdout.take().unwrap();
+    let mut child_stderr = child.stderr.take().unwrap();
+
+    let t1 = thread::spawn(move || io::copy(&mut child_stdout, &mut io::stdout()));
+    let t2 = thread::spawn(move || io::copy(&mut child_stderr, &mut io::stderr()));
+
+    let status = child.wait().unwrap();
+    match status.code() {
+        Some(33) => {}
+        Some(35) => panic!("Test failed"),
+        other => panic!("Test failed with unexpected exit code {other:?}"),
+    }
+
+    t1.join().unwrap().unwrap();
+    t2.join().unwrap().unwrap();
+}

--- a/tests/integration/test_kernel/Cargo.toml
+++ b/tests/integration/test_kernel/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "test_kernel"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+kernel = { path = "../../../kernel" }
+uart_16550 = "0.3.0"
+heapless = { version = "0.7.16", default-features = false }

--- a/tests/integration/test_kernel/src/bin/basic.rs
+++ b/tests/integration/test_kernel/src/bin/basic.rs
@@ -2,23 +2,18 @@
 #![no_main]
 #![feature(abi_x86_interrupt)]
 
-use bootloader_api::{entry_point, BootInfo};
-use core::panic::PanicInfo;
-use kernel::println;
+use test_kernel::prelude::*;
 
 entry_point!(main);
 
 fn main(boot_info: &'static mut BootInfo) -> ! {
     kernel::init(boot_info);
-
-    println!("it works");
-
-    #[allow(clippy::empty_loop)]
-    loop {}
+    exit_qemu(QemuExitCode::Success)
 }
 
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
-    println!("{info}");
-    loop {}
+    use core::fmt::Write;
+    writeln!(serial(), "{info}").unwrap();
+    exit_qemu(QemuExitCode::Failed);
 }

--- a/tests/integration/test_kernel/src/bin/handle_breakpoint.rs
+++ b/tests/integration/test_kernel/src/bin/handle_breakpoint.rs
@@ -1,0 +1,22 @@
+#![no_std]
+#![no_main]
+#![feature(abi_x86_interrupt)]
+
+use test_kernel::prelude::*;
+
+entry_point!(main);
+
+fn main(boot_info: &'static mut BootInfo) -> ! {
+    kernel::init(boot_info);
+
+    kernel::x86_64::instructions::interrupts::int3();
+
+    exit_qemu(QemuExitCode::Success)
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    use core::fmt::Write;
+    writeln!(serial(), "{info}").unwrap();
+    exit_qemu(QemuExitCode::Failed);
+}

--- a/tests/integration/test_kernel/src/bin/handle_stack_overflow.rs
+++ b/tests/integration/test_kernel/src/bin/handle_stack_overflow.rs
@@ -1,0 +1,33 @@
+#![no_std]
+#![no_main]
+#![feature(abi_x86_interrupt)]
+
+use test_kernel::prelude::*;
+
+entry_point!(main);
+
+fn main(boot_info: &'static mut BootInfo) -> ! {
+    kernel::init(boot_info);
+
+    #[allow(unconditional_recursion)]
+    fn stack_overflow() {
+        stack_overflow();
+    }
+    stack_overflow();
+
+    exit_qemu(QemuExitCode::Failed)
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    use core::fmt::Write;
+
+    let mut buf = heapless::String::<512>::new();
+    write!(buf, "{info}").unwrap();
+    if buf.contains("double fault") {
+        exit_qemu(QemuExitCode::Success);
+    } else {
+        writeln!(serial(), "{info}").unwrap();
+        exit_qemu(QemuExitCode::Failed);
+    }
+}

--- a/tests/integration/test_kernel/src/lib.rs
+++ b/tests/integration/test_kernel/src/lib.rs
@@ -1,0 +1,33 @@
+#![no_std]
+
+use core::unreachable;
+
+pub mod prelude {
+    pub use super::{exit_qemu, serial, QemuExitCode};
+    pub use core::panic::PanicInfo;
+    pub use kernel::bootloader_api::{entry_point, BootInfo};
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum QemuExitCode {
+    Success = 0x10,
+    Failed = 0x11,
+}
+
+pub fn exit_qemu(exit_code: QemuExitCode) -> ! {
+    use kernel::x86_64::instructions::port::Port;
+
+    unsafe {
+        let mut port = Port::new(0xf4);
+        port.write(exit_code as u32);
+    }
+
+    unreachable!()
+}
+
+pub fn serial() -> uart_16550::SerialPort {
+    let mut port = unsafe { uart_16550::SerialPort::new(0x3F8) };
+    port.init();
+    port
+}


### PR DESCRIPTION
I diverged from the way tests are implemented in `blog_os`:
* Since we don't use `bootimage`, I had to implement our own runner. I based the implementation on `bootloader`'s tests
* I didn't include any way to run unit tests. They obfuscate kernel's code and I don't  think we need them.

The idea is simple. We have a `test_kernel` crate that communicates with qemu and allows us to freely customize everything (e.g panic handler for tests that should panic). Each test runs qemu with a different binary from `test_kernel` crate.

btw I discovered that breakpoint interrupt handling doesn't work, I made a new issue https://github.com/grupacosmo/cosmos/issues/19