### PR TITLE
fix general protection fault after breakpoint

### DIFF
--- a/kernel/src/interrupt.rs
+++ b/kernel/src/interrupt.rs
@@ -116,8 +116,8 @@ fn init_gdt() {
     // Above we ensure that the code and TSS selectors point to valid entries
     unsafe {
         // At this point the SS (stack segment) register contains selector with index 2,
-        // which is the index of TSS. You can call `println("{:?}", SS::get_reg());` to see this for
-        // yourself. Set it to 0 to avoid issues.
+        // which happens to be the index of TSS. Set it to 0 to avoid issues.
+        // You can call `println!("{:?}", (SS::get_reg(), selectors));` to see this for yourself.
         SS::set_reg(gdt::SegmentSelector::NULL);
         CS::set_reg(selectors.code_selector);
         tables::load_tss(selectors.tss_selector);


### PR DESCRIPTION
closing #19 

Double fault is raised when there is no handler setup for any other interrupt, so I added a bunch of handlers to find out what was causing the issue. It turns out it was general protection fault. I left the handlers in the PR as they will be useful in the future.

Then I found solution in [this](https://github.com/phil-opp/blog_os/discussions/1005#discussioncomment-1690607) comment that seems to fix the issue, so I implemented it and explained it (i can only hope that my explanation is correct lol)
