### PR TITLE
Implement paging

### DIFF
--- a/kernel/src/interrupt.rs
+++ b/kernel/src/interrupt.rs
@@ -1,5 +1,6 @@
 use crate::println;
 use spin::once::Once;
+use x86_64::registers::control::Cr2;
 use x86_64::structures::idt::PageFaultErrorCode;
 use x86_64::{
     instructions::tables,
@@ -135,9 +136,16 @@ extern "x86-interrupt" fn breakpoint_handler(frame: InterruptStackFrame) {
 
 extern "x86-interrupt" fn page_fault_handler(
     frame: InterruptStackFrame,
-    _error_code: PageFaultErrorCode,
+    error_code: PageFaultErrorCode,
 ) {
-    panic!("Exception: page fault\n{:#?}", frame)
+    let accessed_addr = Cr2::read();
+
+    panic!(
+        "Exception: page fault\n\
+         Accessed address: {accessed_addr:?}\n\
+         Error code: {error_code:?}\n\
+         {frame:#?}",
+    )
 }
 
 extern "x86-interrupt" fn invalid_tss_handler(frame: InterruptStackFrame, _error_code: u64) {

--- a/kernel/src/interrupt.rs
+++ b/kernel/src/interrupt.rs
@@ -3,8 +3,8 @@ use core::fmt::Debug;
 use pc_keyboard::{HandleControl, Keyboard};
 use pic8259::ChainedPics;
 use spin::once::Once;
-use x86_64::registers::control::Cr2;
 use spin::Mutex;
+use x86_64::registers::control::Cr2;
 use x86_64::structures::idt::PageFaultErrorCode;
 use x86_64::{
     instructions,

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -2,14 +2,22 @@
 #![no_main]
 #![feature(abi_x86_interrupt)]
 
-use bootloader_api::BootInfo;
+use bootloader_api::{config::Mapping, BootInfo, BootloaderConfig};
 
 pub mod interrupt;
 pub mod logger;
+pub mod memory;
 pub mod vga;
 
 pub use bootloader_api;
 pub use x86_64;
+use x86_64::VirtAddr;
+
+pub static BOOTLOADER_CONFIG: BootloaderConfig = {
+    let mut config = BootloaderConfig::new_default();
+    config.mappings.physical_memory = Some(Mapping::Dynamic);
+    config
+};
 
 pub fn init(boot_info: &'static mut BootInfo) {
     interrupt::init();
@@ -18,4 +26,14 @@ pub fn init(boot_info: &'static mut BootInfo) {
     let vga = vga::Writer::new(framebuffer);
 
     logger::init_global(vga);
+
+    let Some(physical_memory_offset) = boot_info
+        .physical_memory_offset
+        .into_option()
+        .map(VirtAddr::new)
+    else {
+        panic!("physical_memory_offset in not present, make sure that `map-physical-memory` BootloaderConfig option is enabled");
+    };
+
+    memory::init_global(physical_memory_offset, &boot_info.memory_regions);
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -4,9 +4,9 @@
 
 use bootloader_api::{entry_point, BootInfo};
 use core::panic::PanicInfo;
-use kernel::println;
+use kernel::{println, BOOTLOADER_CONFIG};
 
-entry_point!(main);
+entry_point!(main, config = &BOOTLOADER_CONFIG);
 
 fn main(boot_info: &'static mut BootInfo) -> ! {
     kernel::init(boot_info);

--- a/kernel/src/memory.rs
+++ b/kernel/src/memory.rs
@@ -1,0 +1,189 @@
+use bootloader_api::info::{MemoryRegion, MemoryRegionKind, MemoryRegions};
+use spin::{Mutex, Once};
+use x86_64::structures::paging::mapper::MapToError;
+use x86_64::structures::paging::{
+    FrameAllocator, Mapper, OffsetPageTable, Page, PageTableFlags, PhysFrame, Size4KiB, Translate,
+};
+use x86_64::{structures::paging::PageTable, PhysAddr, VirtAddr};
+
+pub static MEMORY_MANAGER: Once<Mutex<MemoryManager>> = Once::new();
+
+/// # Panics
+/// The function will panic if it is called more than once.
+pub fn init_global(physical_memory_offset: VirtAddr, memory_regions: &'static MemoryRegions) {
+    let manager = unsafe { MemoryManager::new(physical_memory_offset, memory_regions) };
+    MEMORY_MANAGER.call_once(|| Mutex::new(manager));
+}
+
+pub struct MemoryManager {
+    mapper: OffsetPageTable<'static>,
+    frame_allocator: BootInfoFrameAllocator,
+}
+
+impl MemoryManager {
+    /// Creates new instance of [`MemoryManager`]
+    ///
+    /// ## Safety
+    ///
+    /// Caller of this function mus guarantee that the complete physical memory is mapped to
+    /// virtual memory at the passed `physical_memory_offset`.
+    ///
+    /// Caller of this function  must guarantee that the passed
+    /// `memory_regions` are valid. The main requirement is that all frames that are marked
+    /// as `USABLE` in it are really unused.
+    ///
+    /// This function must be called only once to avoid aliasing `&mut` references (which is undefined behavior).
+    unsafe fn new(
+        physical_memory_offset: VirtAddr,
+        memory_regions: &'static MemoryRegions,
+    ) -> Self {
+        Self {
+            mapper: unsafe { init_mapper(physical_memory_offset) },
+            frame_allocator: unsafe { BootInfoFrameAllocator::init(memory_regions) },
+        }
+    }
+
+    /// Provides the physical address to which the virtual address has been mapped to.
+    /// Returns [`None`] if there is no valid mapping for the given virtual address.
+    pub fn translate_address(&self, addr: VirtAddr) -> Option<PhysAddr> {
+        self.mapper.translate_addr(addr)
+    }
+
+    /// Allocates frames for virtual memory region.
+    /// * `region_start` - virtual address at which the region starts
+    /// * `region_size` - size of the region
+    /// * `flags` - combination of flags for memory pages
+    ///
+    /// [`MapToError`] determines whether an error occurred during frame allocation or page
+    /// mapping.
+    /// # Example
+    /// ```
+    ///let memory_namager = MEMORY_MANAGER.get().unwrap();
+    ///memory_namager
+    ///    .lock()
+    ///    .allocate_frames_for_memory_region(
+    ///        0x4242_4242_0000_u64,
+    ///        0x4000,
+    ///        PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+    ///    )
+    ///    .expect("failed to allocate pages");
+    /// ```
+    pub fn allocate_frames_for_memory_region(
+        &mut self,
+        region_start: u64,
+        region_size: usize,
+        flags: PageTableFlags,
+    ) -> Result<(), MapToError<Size4KiB>> {
+        // Calculate which pages contain addresses from given memory region
+        // and createa range of that pages
+        let page_range = {
+            let region_start = VirtAddr::new(region_start as u64);
+            // Substract 1 to get inclusive bound
+            let region_end = region_start + region_size - 1u64;
+            let region_start_page = Page::containing_address(region_start);
+            let region_end_page = Page::containing_address(region_end);
+            Page::range_inclusive(region_start_page, region_end_page)
+        };
+
+        for page in page_range {
+            // Allocate avalible USABLE memory frame
+            let frame = self
+                .frame_allocator
+                .allocate_frame()
+                .ok_or(MapToError::FrameAllocationFailed)?;
+
+            // Map page to allocated memory frame
+            unsafe {
+                self.mapper
+                    .map_to(page, frame, flags, &mut self.frame_allocator)?
+                    .flush()
+            };
+        }
+
+        Ok(())
+    }
+}
+
+/// Initialize a new OffsetPageTable which allows for mapping virtual pages to the physical memory
+/// frames.
+///
+/// ## Safety
+///
+/// Caller of this function must guarantee that the
+/// complete physical memory is mapped to virtual memory at the passed
+/// `physical_memory_offset`.
+///
+/// This function must be called only once to avoid aliasing `&mut` references (which is undefined behavior).
+unsafe fn init_mapper(physical_memory_offset: VirtAddr) -> OffsetPageTable<'static> {
+    let level_4_table = active_level_4_table(physical_memory_offset);
+    OffsetPageTable::new(level_4_table, physical_memory_offset)
+}
+
+/// Returns a mutable reference to the active level 4 table.
+///
+/// ## Safety
+///
+/// Caller of this function  must guarantee that the
+/// complete physical memory is mapped to virtual memory at the passed
+/// `physical_memory_offset`.
+///
+/// This function must be called only once to avoid aliasing `&mut` references (which is undefined behavior).
+unsafe fn active_level_4_table(physical_memory_offset: VirtAddr) -> &'static mut PageTable {
+    use x86_64::registers::control::Cr3;
+
+    // Get the frame where the Level 4 table is stored
+    // That table occupies whole frame
+    let (level_4_table_frame, _) = Cr3::read();
+
+    // Get virtual address of frame's start
+    let phys = level_4_table_frame.start_address();
+    let virt = physical_memory_offset + phys.as_u64();
+
+    // Obtain mutable pointer to the table
+    let page_table_ptr: *mut PageTable = virt.as_mut_ptr();
+
+    &mut *page_table_ptr // unsafe
+}
+
+/// A FrameAllocator that returns usable frames from the bootloader's memory map.
+struct BootInfoFrameAllocator {
+    memory_regions: &'static [MemoryRegion],
+    next: usize,
+}
+
+impl BootInfoFrameAllocator {
+    /// Create a FrameAllocator from the passed memory map.
+    ///
+    /// ## Safety
+    ///
+    /// Caller of this function  must guarantee that the passed
+    /// `memory_regions` are valid. The main requirement is that all frames that are marked
+    /// as `USABLE` in it are really unused.
+    unsafe fn init(memory_regions: &'static MemoryRegions) -> Self {
+        BootInfoFrameAllocator {
+            memory_regions,
+            next: 0,
+        }
+    }
+
+    /// Returns an iterator over the usable frames specified in [`MemoryRegions`].
+    fn usable_frames(&self) -> impl Iterator<Item = PhysFrame> {
+        let regions = self.memory_regions.iter();
+        // get usable regions
+        let usable_regions = regions.filter(|r| r.kind == MemoryRegionKind::Usable);
+        // map each region to its address range
+        let addr_ranges = usable_regions.map(|r| r.start..r.end);
+        // transform to an iterator of frame start addresses
+        let frame_addresses = addr_ranges.flat_map(|r| r.step_by(4096));
+        // create `PhysFrame` types from the start addresses
+        frame_addresses.map(|addr| PhysFrame::containing_address(PhysAddr::new(addr)))
+    }
+}
+
+unsafe impl FrameAllocator<Size4KiB> for BootInfoFrameAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysFrame> {
+        let frame = self.usable_frames().nth(self.next);
+        self.next += 1;
+        frame
+    }
+}

--- a/kernel/src/memory.rs
+++ b/kernel/src/memory.rs
@@ -70,14 +70,14 @@ impl MemoryManager {
     /// ```
     pub fn allocate_frames_for_memory_region(
         &mut self,
-        region_start: u64,
+        region_start: VirtAddr,
         region_size: usize,
         flags: PageTableFlags,
     ) -> Result<(), MapToError<Size4KiB>> {
         // Calculate which pages contain addresses from given memory region
         // and createa range of that pages
         let page_range = {
-            let region_start = VirtAddr::new(region_start as u64);
+            let region_start = VirtAddr::new(region_start.as_u64());
             // Substract 1 to get inclusive bound
             let region_end = region_start + region_size - 1u64;
             let region_start_page = Page::containing_address(region_start);

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -3,3 +3,5 @@ mod runner;
 test!(basic);
 test!(handle_stack_overflow);
 test!(handle_breakpoint);
+test!(handle_page_fault);
+test!(frame_allocation);

--- a/tests/integration/test_kernel/src/bin/basic.rs
+++ b/tests/integration/test_kernel/src/bin/basic.rs
@@ -2,9 +2,10 @@
 #![no_main]
 #![feature(abi_x86_interrupt)]
 
+use kernel::BOOTLOADER_CONFIG;
 use test_kernel::prelude::*;
 
-entry_point!(main);
+entry_point!(main, config = &BOOTLOADER_CONFIG);
 
 fn main(boot_info: &'static mut BootInfo) -> ! {
     kernel::init(boot_info);

--- a/tests/integration/test_kernel/src/bin/frame_allocation.rs
+++ b/tests/integration/test_kernel/src/bin/frame_allocation.rs
@@ -1,0 +1,49 @@
+#![no_std]
+#![no_main]
+#![feature(abi_x86_interrupt)]
+
+use kernel::{
+    memory::MEMORY_MANAGER,
+    x86_64::{structures::paging::PageTableFlags, VirtAddr},
+    BOOTLOADER_CONFIG,
+};
+use test_kernel::prelude::*;
+
+entry_point!(main, config = &BOOTLOADER_CONFIG);
+
+fn main(boot_info: &'static mut BootInfo) -> ! {
+    kernel::init(boot_info);
+
+    let memory_namager = MEMORY_MANAGER.get().unwrap();
+
+    let region_start = 0x4242_4242_0000_u64;
+
+    memory_namager
+        .lock()
+        .allocate_frames_for_memory_region(
+            region_start,
+            0x4000,
+            PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+        )
+        .expect("failed to allocate pages");
+
+    let virt = VirtAddr::new(region_start);
+    let phys = memory_namager.lock().translate_address(virt);
+
+    assert_ne!(phys, None);
+
+    let ptr = region_start as *mut u8;
+    unsafe { ptr.write_volatile(0x42) };
+    let value = unsafe { ptr.read() };
+
+    assert_eq!(value, 0x42);
+
+    exit_qemu(QemuExitCode::Success)
+}
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    use core::fmt::Write;
+    writeln!(serial(), "{info}").unwrap();
+    exit_qemu(QemuExitCode::Failed);
+}

--- a/tests/integration/test_kernel/src/bin/frame_allocation.rs
+++ b/tests/integration/test_kernel/src/bin/frame_allocation.rs
@@ -16,7 +16,7 @@ fn main(boot_info: &'static mut BootInfo) -> ! {
 
     let memory_namager = MEMORY_MANAGER.get().unwrap();
 
-    let region_start = 0x4242_4242_0000_u64;
+    let region_start = VirtAddr::new(0x4242_4242_0000_u64);
 
     memory_namager
         .lock()
@@ -27,12 +27,11 @@ fn main(boot_info: &'static mut BootInfo) -> ! {
         )
         .expect("failed to allocate pages");
 
-    let virt = VirtAddr::new(region_start);
-    let phys = memory_namager.lock().translate_address(virt);
+    let phys = memory_namager.lock().translate_address(region_start);
 
     assert_ne!(phys, None);
 
-    let ptr = region_start as *mut u8;
+    let ptr = region_start.as_u64() as *mut u8;
     unsafe { ptr.write_volatile(0x42) };
     let value = unsafe { ptr.read() };
 

--- a/tests/integration/test_kernel/src/bin/handle_breakpoint.rs
+++ b/tests/integration/test_kernel/src/bin/handle_breakpoint.rs
@@ -2,9 +2,10 @@
 #![no_main]
 #![feature(abi_x86_interrupt)]
 
+use kernel::BOOTLOADER_CONFIG;
 use test_kernel::prelude::*;
 
-entry_point!(main);
+entry_point!(main, config = &BOOTLOADER_CONFIG);
 
 fn main(boot_info: &'static mut BootInfo) -> ! {
     kernel::init(boot_info);

--- a/tests/integration/test_kernel/src/bin/handle_stack_overflow.rs
+++ b/tests/integration/test_kernel/src/bin/handle_stack_overflow.rs
@@ -2,9 +2,10 @@
 #![no_main]
 #![feature(abi_x86_interrupt)]
 
+use kernel::BOOTLOADER_CONFIG;
 use test_kernel::prelude::*;
 
-entry_point!(main);
+entry_point!(main, config = &BOOTLOADER_CONFIG);
 
 fn main(boot_info: &'static mut BootInfo) -> ! {
     kernel::init(boot_info);


### PR DESCRIPTION
Resolves #17 

The [MemoryManager](https://github.com/0xf4lc0n/cosmos/blob/947bf33eb9d0e00de1d560d75c2a8714d83e92d3/kernel/src/memory.rs#L18C1-L21C2) is useful when it comes to testing or abstracting operations that require both `OffsetPageTable` and `BootInfoFrameAllocator`.

But registering it as singleton hidden behind `Once<Mutex<..>>` may be not very convenient.

In future we will need `MemoryManager` inside `alloc` module or any other module that handles heap allocation.

Saying so there will be no reason to use `MemoryManager` outside of `alloc` module. So we can pass `MemoryManager` directly to that module and provide `Once<Mutex<MemoryManager>>` only for test purposes (by using `#[cfg]` attribute).

Feel free to provide your feedback.
